### PR TITLE
Action setup_jdk - Use actions/setup-java@v3 instead of v2

### DIFF
--- a/actions/setup_jdk/action.yml
+++ b/actions/setup_jdk/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v3.1.1
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.distribution }}

--- a/actions/setup_jdk/action.yml
+++ b/actions/setup_jdk/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.distribution }}


### PR DESCRIPTION
Tested with:
https://github.com/AVISPL/symphony-notifications-shared/runs/6080224966?check_suite_focus=true