### PR TITLE
Check WKF - Default maven goals clean verify

### DIFF
--- a/.github/workflows/check_branch_maven.reusable.workflow.yml
+++ b/.github/workflows/check_branch_maven.reusable.workflow.yml
@@ -21,7 +21,7 @@ on:
         description: 'The goals for the mvn command (optional)'
         required: false
         type: string
-        default: 'clean install'
+        default: 'clean verify'
       maven_other_options:
         description: 'Maven options added at the end of the mvn command, overrides previous options'
         required: false


### PR DESCRIPTION
Check workflow : set default Maven goals to 'clean verify' instead of 'clean install'
Verify is the last phase before install
Executing all phases up to (excluding) install allows to ensure that all the process of building the application is OK, including packaging, running integration tests, and any other plugins which could be attached to the phases up to (including) verify phase.