### PR TITLE
SYUS-12065 [GitHub Workflows] Use latest checkout action everywhere

### DIFF
--- a/.github/workflows/build_branch_npm.reusable.workflow.yml
+++ b/.github/workflows/build_branch_npm.reusable.workflow.yml
@@ -96,7 +96,7 @@ jobs:
       # (so other files written into it will be removed)
       # Checkout current branch
       - name: Checkout
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.1.1
         with:
           # Checkout all branches and tags (required to work with tags)
           fetch-depth: '0' # 0 indicates all history for all branches and tags
@@ -107,7 +107,7 @@ jobs:
       # (feature not available yet)
       # So checkout the actions into local workspace directory and run them from there
       - name: Checkout actions from private repository
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/symphony-devops-workflows
           # Select revision

--- a/.github/workflows/check_branch_maven.reusable.workflow.yml
+++ b/.github/workflows/check_branch_maven.reusable.workflow.yml
@@ -74,7 +74,7 @@ jobs:
       # WARNING checkout repository first because this action resets the checkout directory
       # (so other files written into it will be removed)
       - name: Git checkout current repository/branch
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v4.1.1
         with:
           # TODO HOUSEKEEPING check if fetch-depth 0 is really needed (should not
           #      as no Git tags are manipulated by this workflow)
@@ -87,7 +87,7 @@ jobs:
       # (feature not available yet)
       # So checkout the actions into local workspace directory and run them from there
       - name: Checkout actions from private repository
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/symphony-devops-workflows
           # Select revision

--- a/.github/workflows/dependabot_force_run.reusable.workflow.yml
+++ b/.github/workflows/dependabot_force_run.reusable.workflow.yml
@@ -78,7 +78,7 @@ jobs:
       # (feature not available yet)
       # So checkout the actions into local workspace directory and run them from there
       - name: Checkout actions from private repository
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/symphony-devops-workflows
           # Select revision

--- a/.github/workflows/deploy_branch_maven.reusable.workflow.yml
+++ b/.github/workflows/deploy_branch_maven.reusable.workflow.yml
@@ -117,7 +117,7 @@ jobs:
       # WARNING checkout repository first because this action resets the checkout directory
       # (so other files written into it will be removed)
       - name: Git checkout current repository/branch
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v4.1.1
         with:
           # Checkout all branches and tags (required to work with tags in git_delete_tag action)
           fetch-depth: '0' # 0 indicates all history for all branches and tags
@@ -128,7 +128,7 @@ jobs:
       # (feature not available yet)
       # So checkout the actions into local workspace directory and run them from there
       - name: Checkout actions from private repository
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/symphony-devops-workflows
           # Select revision
@@ -251,7 +251,7 @@ jobs:
       # match labels), in which case workspace will be empty,
       # so need to checkout again required actions from dedicated repository
       - name: Checkout actions from private repository
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/symphony-devops-workflows
           # Select revision

--- a/.github/workflows/release_maven.reusable.workflow.yml
+++ b/.github/workflows/release_maven.reusable.workflow.yml
@@ -128,7 +128,7 @@ jobs:
       # WARNING checkout repository first because this action resets the checkout directory
       # (so other files written into it will be removed)
       - name: Git checkout
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v4.1.1
         with:
           # Select revision
           ref: '${{ inputs.git-ref }}'
@@ -143,7 +143,7 @@ jobs:
       # (feature not available yet)
       # So checkout the actions into local workspace directory and run them from there
       - name: Checkout actions from private repository
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/symphony-devops-workflows
           # Select revision

--- a/.github/workflows/update_artifact_versions.reusable.workflow.yml
+++ b/.github/workflows/update_artifact_versions.reusable.workflow.yml
@@ -64,21 +64,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout AVISPL/${{ env.BASE_REPOSITORY }} (contains modules.txt)
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/${{ env.BASE_REPOSITORY }}
           ref: 'develop'
           path: ./${{ env.BASE_REPOSITORY }}
           token: ${{ secrets.ciToken }}
       - name: Checkout AVISPL/${{ inputs.symphony-module-name }}
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/${{ inputs.symphony-module-name }}
           ref: '${{ inputs.branch }}'
           path: ./${{ inputs.symphony-module-name }}
           token: ${{ secrets.ciToken }}
       - name: Checkout AVISPL/symphony-devops-workflows
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/symphony-devops-workflows
           ref: 'develop'
@@ -153,7 +153,7 @@ jobs:
           wait-for-completion-timeout: 10m
       # checking out the module again in order to get latest updated version from previous release step
       - name: Checkout AVISPL/${{ inputs.symphony-module-name }}
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v4.1.1
         with:
           repository: AVISPL/${{ inputs.symphony-module-name }}
           ref: '${{ inputs.branch }}'

--- a/actions/kubernetes_update_deployment/action.yml
+++ b/actions/kubernetes_update_deployment/action.yml
@@ -80,7 +80,7 @@ runs:
     # Checkout the Git repository with Kubernetes deployment descriptors
     # into local workspace directory
     - name: Checkout Kubernetes deployer repository
-      uses: actions/checkout@v3.0.1
+      uses: actions/checkout@v4.1.1
       with:
         # Repository to be checked out
         repository: 'AVISPL/symphony-kubernetes-deployer'

--- a/actions/yaml_dummy_update_file_commit_push/action.yml
+++ b/actions/yaml_dummy_update_file_commit_push/action.yml
@@ -30,7 +30,7 @@ inputs:
   workspace-checkout-dir-git-clean:
     description: >
       Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching
-      See actions/checkout@v3.0.1 "clean" option for details
+      See actions/checkout@v4.1.1 "clean" option for details
       Should be true when caller assumes that some contents might already exist
       in temporary checkout dir, which needs to be updated to get latest repository contents,
       to avoid issues with unexpected local changes
@@ -52,7 +52,7 @@ runs:
   steps:
       # Checkout specified repository/ref
       - name: Git checkout repository/branch
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v4.1.1
         with:
           # Repository to be checked out
           repository: ${{ inputs.repository }}


### PR DESCRIPTION
Have verified there is no breaking change with older versions (https://github.com/actions/checkout/releases)