### PR TITLE
feat(ci): Add max commit count check for pull requests

### DIFF
--- a/.github/workflows/build_branch_npm.reusable.workflow.yml
+++ b/.github/workflows/build_branch_npm.reusable.workflow.yml
@@ -71,6 +71,21 @@ on:
         required: false
         type: string
         default: '[ "self-hosted", "linux" ]'
+      max-commits-check:
+        description: |
+          Enables the max commit count check on pull requests. When enabled, the workflow
+          will fail if the number of commits in the PR exceeds the max-commits threshold.
+          Only applies when mode is 'check'.
+        type: boolean
+        required: false
+        default: false
+      max-commits:
+        description: |
+          The maximum number of commits allowed in a pull request (inclusive).
+          Only used when max-commits-check is true.
+        type: number
+        required: false
+        default: 5
     #
     secrets:
       # WARNING: secret names do not seem to accept "-" or "_" characters (not documented)
@@ -132,6 +147,13 @@ jobs:
           path: ./.github/symphony-devops-workflows
           # Force clean to avoid leftover changes from previous runs in workspace in current runner
           clean: 'true'
+
+      - name: Max commit count check
+        if: ${{ inputs.max-commits-check && inputs.mode == 'check' && github.event_name == 'pull_request' }}
+        uses: ./.github/symphony-devops-workflows/actions/max_commit_count
+        with:
+          max-commits: ${{ inputs.max-commits }}
+          token: ${{ secrets.ciToken }}
 
       - name: Install jq
         uses: ./.github/symphony-devops-workflows/actions/install_jq

--- a/.github/workflows/check_branch_maven.reusable.workflow.yml
+++ b/.github/workflows/check_branch_maven.reusable.workflow.yml
@@ -73,6 +73,20 @@ on:
         type: number
         required: false
         default: 5
+      max-commits-check:
+        description: |
+          Enables the max commit count check on pull requests. When enabled, the workflow
+          will fail if the number of commits in the PR exceeds the max-commits threshold.
+        type: boolean
+        required: false
+        default: false
+      max-commits:
+        description: |
+          The maximum number of commits allowed in a pull request (inclusive).
+          Only used when max-commits-check is true.
+        type: number
+        required: false
+        default: 5
     #
     secrets:
       # WARNING: secret names do not seem to accept "-" or "_" characters (not documented)
@@ -87,8 +101,8 @@ on:
         required: false
       commitUserName:
         description: |
-          User name to be used as Git committer by the workflow, when the workflow issues new 
-          Git commits (for example when updating deployment files). It is unrelated to the person 
+          User name to be used as Git committer by the workflow, when the workflow issues new
+          Git commits (for example when updating deployment files). It is unrelated to the person
           who ran the workflow. It is recommended to use a technical user dedicated to the CI system.
           For example, if John did run the workflow, and commit user name provided is 'MyCIUser',
           the commit will look like:
@@ -96,6 +110,11 @@ on:
             Committer: MyCIUser
             Signed-off-by: MyCIUser <MyCIUser@...com>
         required: true
+      ciToken:
+        description: |
+          GitHub token (PAT) used by the max commit count check to query PR commit count via GitHub API.
+          Only required when max-commits-check input is true.
+        required: false
 env:
   SONAR_HOST_URL: "https://sonarqube-dev.devvnocsymphony.com/"
   AUTO_RELEASE_COMMIT_ACTOR: ${{ secrets.commitUserName}}
@@ -111,6 +130,8 @@ jobs:
       # Actions read is required by technote-space/workflow-conclusion-action for accessing
       # actions API for getting actions results
       actions: read
+      # Pull-requests read is required by max commit count check to query PR commit count
+      pull-requests: read
 
     # Use runner which has requested labels
     # Note: GitHub does not allow to pass an object as job input (such as an array)
@@ -160,6 +181,13 @@ jobs:
           ref: '${{ inputs.symphony-devops-workflows_ref }}'
           # Indicate where to check out project to
           path: ./.github/symphony-devops-workflows
+
+      - name: Max commit count check
+        if: ${{ inputs.max-commits-check && github.event_name == 'pull_request' && steps.check.outputs.continue == 'true' }}
+        uses: ./.github/symphony-devops-workflows/actions/max_commit_count
+        with:
+          max-commits: ${{ inputs.max-commits }}
+          token: ${{ secrets.ciToken }}
 
       - name: Setup JDK
         if: ${{ steps.check.outputs.continue == 'true' }}

--- a/actions/max_commit_count/action.yml
+++ b/actions/max_commit_count/action.yml
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 AVI-SPL Inc.
+# All Rights Reserved.
+#
+# Enforce maximum commit count on a pull request before merge.
+# Wraps nikwotton/Max-Commit-Count action.
+#
+name: 'Max Commit Count'
+description: 'Fails the workflow if the number of commits in a pull request exceeds the configured maximum'
+
+inputs:
+  max-commits:
+    description: 'The maximum number of commits allowed in a PR (inclusive)'
+    required: true
+  token:
+    description: 'GitHub token used to query the number of commits in the PR'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check max commit count
+      uses: nikwotton/Max-Commit-Count@v1.0.0
+      with:
+        maxCommits: ${{ inputs.max-commits }}
+        token: ${{ inputs.token }}


### PR DESCRIPTION
- Introduced a new action to enforce a maximum commit count on pull requests.
- Updated workflow files to include options for enabling the check and setting the maximum commit limit.